### PR TITLE
fix: datauri behavior incorrect

### DIFF
--- a/lib/utils/image.rb
+++ b/lib/utils/image.rb
@@ -127,7 +127,7 @@ module Metanorma
       # Check whether just the local path or the other specified relative path
       # works.
       def datauri(uri, local_dir = ".")
-        return uri if datauri?(uri) || url?(uri) # || absolute_path?(uri)
+        return uri if datauri?(uri) || url?(uri)
 
         path = [uri, File.join(local_dir, uri)].detect do |p|
           File.exist?(p) ? p : nil

--- a/lib/utils/image.rb
+++ b/lib/utils/image.rb
@@ -129,7 +129,8 @@ module Metanorma
       def datauri(uri, local_dir = ".")
         return uri if datauri?(uri) || url?(uri)
 
-        path = [uri, File.join(local_dir, uri)].detect do |p|
+options = absolute_path?(uri) ? [uri] : [uri, File.join(local_dir, uri)]
+        path = options.detect do |p|
           File.exist?(p) ? p : nil
         end
 

--- a/lib/utils/image.rb
+++ b/lib/utils/image.rb
@@ -127,12 +127,13 @@ module Metanorma
       # Check whether just the local path or the other specified relative path
       # works.
       def datauri(uri, local_dir = ".")
-        return uri if datauri?(uri) || url?(uri) || absolute_path?(uri)
+        return uri if datauri?(uri) || url?(uri) # || absolute_path?(uri)
 
         path = [uri, File.join(local_dir, uri)].detect do |p|
           File.exist?(p) ? p : nil
         end
-        unless path && File.exist?(path)
+
+        unless path
           warn "Image specified at `#{uri}` does not exist."
           return uri # Return original provided location
         end

--- a/spec/img_spec.rb
+++ b/spec/img_spec.rb
@@ -2,6 +2,39 @@ require "spec_helper"
 require "fileutils"
 
 RSpec.describe Metanorma::Utils do
+
+  context "recognises data uris" do
+    it "where the content is an existing file at a relative path" do
+      expect(Metanorma::Utils.datauri("spec/fixtures/rice_image1.png"))
+        .to eq Metanorma::Utils.encode_datauri('spec/fixtures/rice_image1.png')
+    end
+
+    it "where the content is an existing file at an absolute path" do
+      expect(Metanorma::Utils.datauri(File.expand_path("spec/fixtures/rice_image1.png")))
+        .to eq Metanorma::Utils.encode_datauri('spec/fixtures/rice_image1.png')
+    end
+
+    it "where the content is a relative file path pointing to a bogus file" do
+      expect(Metanorma::Utils.datauri("spec/fixtures/bogus.png"))
+        .to eq "spec/fixtures/bogus.png"
+    end
+
+    it "where the content is an absolute file path pointing to a bogus file" do
+      expect(Metanorma::Utils.datauri("D:/spec/fixtures/bogus.png"))
+        .to eq "D:/spec/fixtures/bogus.png"
+    end
+
+    it "where the content is a data/image URI" do
+      expect(Metanorma::Utils.datauri("data1:img/gif,base64,ABBC"))
+        .to eq "data1:img/gif,base64,ABBC"
+    end
+
+    it "where the content is an URL" do
+      expect(Metanorma::Utils.datauri("https://example.com/image.png"))
+        .to eq "https://example.com/image.png"
+    end
+  end
+
   it "recognises data uris" do
     expect(Metanorma::Utils.datauri?("data:img/gif,base64,ABBC"))
       .to eq true


### PR DESCRIPTION
As documented here: https://github.com/metanorma/metanorma-iso/issues/797#event-7452940216

The current datauri behavior is incorrect. This PR provides specs to test against the different cases on whether the data uri is generated given a relative or absolute path.