### PR TITLE
Fix break_up_long_str

### DIFF
--- a/lib/utils/main.rb
+++ b/lib/utils/main.rb
@@ -143,7 +143,7 @@ module Metanorma
 nopunct = LONGSTR_NOPUNCT)
         /^\s*$/.match?(text) and return text
         text.split(/(?=(?:\s|-))/).map do |w|
-          if /^\s*$/.match(text) || (w.size < threshold) then w
+          if /^\s*$/.match(w) || (w.size < threshold) then w
           else
             w.scan(/.{,#{threshold}}/o).map.with_index do |w1, i|
               w1.size < threshold ? w1 : break_up_long_str1(w1, i + 1, nopunct)


### PR DESCRIPTION
This method execution jumps to 5-10-20 seconds on some inputs (see attached).

A fix should either be as in the PR or to extract the `/^\s*$/.match(text)` expression outside the loop depending whether the logic or the code is broken

[39499-20.884957.txt](https://github.com/user-attachments/files/19718100/39499-20.884957.txt)

### Metanorma PR checklist

 - [ ] Breaking changes (list related PRs)
 - [ ] Documentation update required ([create task for this](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] External dependency introduced ([documentation update need](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] Gem with native library introduced

<!-- Feel free to improve/modify the template https://github.com/metanorma/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
