### PR TITLE
chore(ci): cimas sync 2026-06-24 — required_ruby_version >= 3.3, automerge v0.16.4 pin, lutaml Makefile (refs metanorma/ci#274 #283 #281 #300)

### DIFF
--- a/metanorma-utils.gemspec
+++ b/metanorma-utils.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
     f.match(%r{^(test|spec|features|bin|.github)/}) \
     || f.match(%r{Rakefile|bin/rspec})
   end
-  spec.required_ruby_version = Gem::Requirement.new(">= 3.1.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 3.3.0")
 
   spec.add_dependency "asciidoctor", ">= 2"
   spec.add_dependency "concurrent-ruby"


### PR DESCRIPTION
As title. 

 _Generated by Cimas_.